### PR TITLE
feat: add mode wrapper exports

### DIFF
--- a/src/scenes/mode1.ts
+++ b/src/scenes/mode1.ts
@@ -54,6 +54,22 @@ export function startMode1(canvas: HTMLCanvasElement): void {
   });
 }
 
+// ===== SECTION: mode-wrappers-export =====
+// [SECTION_ID]: mode-wrappers-export
+// Purpose: Expose a simple wrapper to launch game modes externally
+
+/**
+ * Wrapper to start Practice Mode — single-animal tracing mode.
+ */
+export function startPracticeMode(canvas: HTMLCanvasElement): void {
+  if (DEBUG_MODE) {
+    console.log('▶️ Practice Mode started');
+  }
+  return startMode1(canvas);
+}
+
+// [AI_EDIT] 2025-02-20 - Added practice mode wrapper for external launch
+
 /**
  * Loads the next animal outline from assets and draws it.
  */

--- a/src/scenes/mode2.ts
+++ b/src/scenes/mode2.ts
@@ -52,6 +52,22 @@ export function startMode2(canvas: HTMLCanvasElement): void {
   });
 }
 
+// ===== SECTION: mode-wrappers-export =====
+// [SECTION_ID]: mode-wrappers-export
+// Purpose: Expose a simple wrapper to launch game modes externally
+
+/**
+ * Wrapper to start Intermediate Mode — multi-animal tracing mode.
+ */
+export function startIntermediateMode(canvas: HTMLCanvasElement): void {
+  if (DEBUG_MODE) {
+    console.log('▶️ Intermediate Mode started');
+  }
+  return startMode2(canvas);
+}
+
+// [AI_EDIT] 2025-02-20 - Added intermediate mode wrapper for external launch
+
 /**
  * Loads 2 or 3 animals and draws them spaced apart on the canvas.
  */


### PR DESCRIPTION
## Summary
- add Practice mode wrapper to startMode1
- add Intermediate mode wrapper to startMode2

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d7ba03ffc8330958f27890bd939f2