### PR TITLE
feat: add fallback auto-start for practice mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@
 
 import { DEBUG_MODE } from './config/settings';
 import { startGameLoop } from './core/gameLoop';
+import { startPracticeMode } from './scenes/mode1';
+import { startIntermediateMode } from './scenes/mode2';
 
 /**
  * Creates a canvas element that fills the screen and resizes with the window.
@@ -44,4 +46,36 @@ function setupCanvas(): HTMLCanvasElement {
 window.addEventListener('load', () => {
   const canvas = setupCanvas();
   startGameLoop(canvas);
+
+  // ===== SECTION: fallback-mode-autostart =====
+  // [SECTION_ID]: fallback-mode-autostart
+  // Purpose: Auto-start Practice Mode if no mode is selected manually
+  const global = window as typeof window & {
+    __modeStarted?: boolean;
+    practiceMode?: () => void;
+    intermediateMode?: () => void;
+  };
+
+  // Preserve any flag set before this script runs
+  global.__modeStarted = global.__modeStarted ?? false;
+
+  // Expose manual launchers for developer testing
+  global.practiceMode = () => {
+    global.__modeStarted = true;
+    startPracticeMode(canvas);
+  };
+  global.intermediateMode = () => {
+    global.__modeStarted = true;
+    startIntermediateMode(canvas);
+  };
+
+  // [AI_EDIT] 2025-08-02 - Added fallback auto-start for Practice Mode
+
+  // If no mode has been launched manually, start Practice Mode
+  if (!global.__modeStarted) {
+    if (DEBUG_MODE) {
+      console.log('▶️ Auto-starting Practice Mode (fallback)');
+    }
+    global.practiceMode();
+  }
 });


### PR DESCRIPTION
## Summary
- start Practice Mode automatically if no mode is chosen
- expose `practiceMode` and `intermediateMode` helpers for manual testing
- log fallback start in debug mode

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d7c8cf11c8330ae2a4ecac95dbf30