### PR TITLE
feat: add start menu for practice mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,21 @@
 <!DOCTYPE html>
+<!-- ===== FILE: index.html ===== -->
+<!-- [SECTION_ID]: ui-start-button-menu -->
+<!-- Purpose: Entry page with start menu and game canvas -->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Toddler Animal Tracing Game</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <!-- ===== SECTION: start-button-menu ===== -->
+  <!-- [SECTION_ID]: ui-start-button-menu -->
+  <div id="menu">
+    <button id="start-btn">Start Practice Mode</button>
+  </div>
+  <canvas id="trace-game-canvas"></canvas>
   <script type="module" src="src/main.ts"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,17 +5,14 @@
 import { DEBUG_MODE } from './config/settings';
 import { startGameLoop } from './core/gameLoop';
 import { startPracticeMode } from './scenes/mode1';
-import { startIntermediateMode } from './scenes/mode2';
 
 /**
- * Creates a canvas element that fills the screen and resizes with the window.
+ * Configures the on-page canvas to fill the screen.
  * Shows a debug banner if DEBUG_MODE is true.
  */
 function setupCanvas(): HTMLCanvasElement {
-  const canvas = document.createElement('canvas');
-  canvas.id = 'trace-game-canvas';
+  const canvas = document.getElementById('trace-game-canvas') as HTMLCanvasElement;
   document.body.style.margin = '0';
-  document.body.appendChild(canvas);
 
   const resize = () => {
     canvas.width = window.innerWidth;
@@ -42,40 +39,27 @@ function setupCanvas(): HTMLCanvasElement {
   return canvas;
 }
 
+// ===== SECTION: start-button-menu-setup =====
+// [SECTION_ID]: ui-start-button-menu
+// Purpose: Handle Start button click and hide menu
+function setupMenu(canvas: HTMLCanvasElement): void {
+  const button = document.getElementById('start-btn') as HTMLButtonElement | null;
+  if (!button) {
+    console.error('[UI] Start button not found');
+    return;
+  }
+  button.addEventListener('click', () => {
+    startPracticeMode(canvas);
+    const menu = document.getElementById('menu');
+    if (menu) {
+      menu.style.display = 'none';
+    }
+  });
+}
+
 // Wait for the page to load before initializing
 window.addEventListener('load', () => {
   const canvas = setupCanvas();
   startGameLoop(canvas);
-
-  // ===== SECTION: fallback-mode-autostart =====
-  // [SECTION_ID]: fallback-mode-autostart
-  // Purpose: Auto-start Practice Mode if no mode is selected manually
-  const global = window as typeof window & {
-    __modeStarted?: boolean;
-    practiceMode?: () => void;
-    intermediateMode?: () => void;
-  };
-
-  // Preserve any flag set before this script runs
-  global.__modeStarted = global.__modeStarted ?? false;
-
-  // Expose manual launchers for developer testing
-  global.practiceMode = () => {
-    global.__modeStarted = true;
-    startPracticeMode(canvas);
-  };
-  global.intermediateMode = () => {
-    global.__modeStarted = true;
-    startIntermediateMode(canvas);
-  };
-
-  // [AI_EDIT] 2025-08-02 - Added fallback auto-start for Practice Mode
-
-  // If no mode has been launched manually, start Practice Mode
-  if (!global.__modeStarted) {
-    if (DEBUG_MODE) {
-      console.log('▶️ Auto-starting Practice Mode (fallback)');
-    }
-    global.practiceMode();
-  }
+  setupMenu(canvas);
 });

--- a/style.css
+++ b/style.css
@@ -1,0 +1,42 @@
+/* ===== FILE: style.css ===== */
+/* [SECTION_ID]: ui-start-button-menu */
+/* Purpose: Style the start menu button for a toddler-friendly UI */
+
+html, body {
+  margin: 0;
+  height: 100%;
+}
+
+#menu {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff7cc;
+}
+
+#start-btn {
+  font-size: 2rem;
+  padding: 1rem 2rem;
+  background: #ff7f50;
+  color: #ffffff;
+  border: none;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+#start-btn:active {
+  transform: scale(0.95);
+}
+
+@media (max-width: 600px) {
+  #start-btn {
+    font-size: 1.5rem;
+    padding: 0.75rem 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add start menu with Start Practice Mode button
- hook button to start practice mode and hide menu
- style the menu for large toddler-friendly button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d7d89bb7c8330b54dbe136386bb37