### PR TITLE
feat(ui-home-screen): add landing screen and practice mode hookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!-- ===== FILE: index.html ===== -->
-<!-- [SECTION_ID]: ui-start-button-menu -->
-<!-- Purpose: Entry page with start menu and game canvas -->
+<!-- [SECTION_ID]: ui-home-screen -->
+<!-- Purpose: Landing screen with title and mode buttons -->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -10,12 +10,17 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <!-- ===== SECTION: start-button-menu ===== -->
-  <!-- [SECTION_ID]: ui-start-button-menu -->
-  <div id="menu">
-    <button id="start-btn">Start Practice Mode</button>
+  <!-- ===== SECTION: home-screen ===== -->
+  <!-- [SECTION_ID]: ui-home-screen -->
+  <div id="home-screen">
+    <h1>Toddler Animal Tracing Game</h1>
+    <p class="subtitle">Trace the shapes. Meet the animals.</p>
+    <p class="onboarding">👋 Ready to trace?</p>
+    <button id="practice-btn" class="mode-btn">Start Practice Mode</button>
+    <button id="intermediate-btn" class="mode-btn" disabled>Start Intermediate Mode</button>
   </div>
   <canvas id="trace-game-canvas"></canvas>
   <script type="module" src="src/main.ts"></script>
+  <!-- [AI_EDIT] 2025-02-24 - Created home screen with mode buttons -->
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,22 +39,31 @@ function setupCanvas(): HTMLCanvasElement {
   return canvas;
 }
 
-// ===== SECTION: start-button-menu-setup =====
-// [SECTION_ID]: ui-start-button-logic
-// Purpose: Attach Start button to Practice Mode launch
+// ===== SECTION: home-screen-setup =====
+// [SECTION_ID]: ui-home-screen
+// Purpose: Attach Practice Mode button and hide landing screen
 
 /**
- * Hooks the Start button so the game begins only when tapped.
+ * Hooks the Practice Mode button so the game begins only when tapped.
  */
-function setupMenu(): void {
-  const btn = document.getElementById('start-btn');
+function setupHomeScreen(): void {
+  const btn = document.getElementById('practice-btn');
+  const home = document.getElementById('home-screen');
+  const canvas = document.getElementById('trace-game-canvas') as HTMLCanvasElement;
   btn?.addEventListener('click', () => {
-    startPracticeMode();
-    const menu = document.getElementById('menu');
-    if (menu) menu.style.display = 'none';
+    startPracticeMode(canvas);
+    if (DEBUG_MODE) {
+      console.log('[DEBUG] 🎮 Practice mode started');
+    }
+    if (home) {
+      home.classList.add('fade-out');
+      setTimeout(() => {
+        home.style.display = 'none';
+      }, 500);
+    }
   });
 }
-// [AI_EDIT] 2025-02-21 - Added start button listener for Practice Mode
+// [AI_EDIT] 2025-02-24 - Added home screen logic for Practice Mode
 
 // Wait for the page to load before initializing
 window.addEventListener('load', () => {
@@ -63,5 +72,5 @@ window.addEventListener('load', () => {
 });
 
 window.addEventListener('DOMContentLoaded', () => {
-  setupMenu();
+  setupHomeScreen();
 });

--- a/style.css
+++ b/style.css
@@ -1,42 +1,86 @@
 /* ===== FILE: style.css ===== */
-/* [SECTION_ID]: ui-start-button-menu */
-/* Purpose: Style the start menu button for a toddler-friendly UI */
+/* [SECTION_ID]: ui-home-screen */
+/* Purpose: Style the landing screen and mode buttons */
 
 html, body {
   margin: 0;
   height: 100%;
 }
 
-#menu {
+#home-screen {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   background: #fff7cc;
+  text-align: center;
+  font-family: sans-serif;
 }
 
-#start-btn {
-  font-size: 2rem;
+#home-screen h1 {
+  font-size: 2.5rem;
+  margin: 0.5rem 0;
+}
+
+.subtitle {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.onboarding {
+  font-size: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.mode-btn {
+  font-size: 1.5rem;
   padding: 1rem 2rem;
+  margin: 0.5rem;
   background: #ff7f50;
   color: #ffffff;
   border: none;
   border-radius: 12px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
   cursor: pointer;
+  transition: transform 0.2s;
 }
 
-#start-btn:active {
+.mode-btn:active {
   transform: scale(0.95);
 }
 
+.mode-btn:hover,
+.mode-btn:focus {
+  transform: scale(1.05);
+}
+
+.mode-btn:disabled {
+  background: #cccccc;
+  cursor: not-allowed;
+}
+
+.fade-out {
+  animation: fadeOut 0.5s forwards;
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
 @media (max-width: 600px) {
-  #start-btn {
-    font-size: 1.5rem;
+  #home-screen h1 {
+    font-size: 2rem;
+  }
+  .mode-btn {
+    font-size: 1.25rem;
     padding: 0.75rem 1.5rem;
   }
 }
+
+/* [AI_EDIT] 2025-02-24 - Styled home screen with responsive mode buttons */


### PR DESCRIPTION
## Summary
- create toddler-friendly home screen with title, subtitle, and mode buttons
- style landing page with centered layout, large buttons, and fade-out transition
- wire Practice Mode button to start game and log debug info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d80b384fc833084235e9b72a01c7e