### PR TITLE
fix: use js modules for browser

### DIFF
--- a/dist/core/gameLoop.js
+++ b/dist/core/gameLoop.js
@@ -1,7 +1,8 @@
 // ===== FILE: gameLoop.ts =====
 // [SECTION_ID]: game-loop-core
 // Purpose: Contains the central game loop for updating and drawing the game
-import { DEBUG_MODE } from '../config/settings';
+// [AI_EDIT] 2025-08-03 - Added .js extension to config import
+import { DEBUG_MODE } from '../config/settings.js';
 /** Starts the placeholder game loop */
 export function startGameLoop(canvas) {
     if (DEBUG_MODE) {

--- a/dist/core/traceEngine.js
+++ b/dist/core/traceEngine.js
@@ -10,7 +10,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { DEBUG_MODE, TRACE_DISTANCE_THRESHOLD, SOUND_ENABLED, } from '../config/settings';
+import { DEBUG_MODE, TRACE_DISTANCE_THRESHOLD, SOUND_ENABLED,
+// [AI_EDIT] 2025-08-03 - Added .js extension to config import
+ } from '../config/settings.js';
 // Keep the canvas reference so we can remove listeners later
 let activeCanvas = null;
 // Holds the points traced by the user's finger

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,9 +1,10 @@
 // ===== FILE: main.ts =====
 // [SECTION_ID]: canvas-init-main
 // Purpose: Initialize the full-screen canvas and kick off the game loop
-import { DEBUG_MODE } from './config/settings';
-import { startGameLoop } from './core/gameLoop';
-import { startPracticeMode } from './scenes/mode1';
+// [AI_EDIT] 2025-08-03 - Added .js extensions for browser module support
+import { DEBUG_MODE } from './config/settings.js';
+import { startGameLoop } from './core/gameLoop.js';
+import { startPracticeMode } from './scenes/mode1.js';
 /**
  * Configures the on-page canvas to fill the screen.
  * Shows a debug banner if DEBUG_MODE is true.

--- a/dist/scenes/mode1.js
+++ b/dist/scenes/mode1.js
@@ -10,9 +10,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { startTracking, stopTracking, drawOutline, isTraceAccurate, loadAnimalOutline, } from '../core/traceEngine';
-import { DEBUG_MODE } from '../config/settings';
-import { showDebugPanel, updateTraceCount, clearDebugPanel, } from '../ui/debugPanel';
+// [AI_EDIT] 2025-08-03 - Added .js extensions for browser module support
+import { startTracking, stopTracking, drawOutline, isTraceAccurate, loadAnimalOutline, } from '../core/traceEngine.js';
+import { DEBUG_MODE } from '../config/settings.js';
+import { showDebugPanel, updateTraceCount, clearDebugPanel, } from '../ui/debugPanel.js';
 let ctx;
 let currentOutline = [];
 let animating = false;

--- a/dist/scenes/mode2.js
+++ b/dist/scenes/mode2.js
@@ -10,8 +10,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { startTracking, stopTracking, drawOutline, isTraceAccurate, loadAnimalOutline, } from '../core/traceEngine';
-import { DEBUG_MODE } from '../config/settings';
+// [AI_EDIT] 2025-08-03 - Added .js extensions for browser module support
+import { startTracking, stopTracking, drawOutline, isTraceAccurate, loadAnimalOutline, } from '../core/traceEngine.js';
+import { DEBUG_MODE } from '../config/settings.js';
 // Canvas drawing context
 let ctx;
 // Animals currently visible

--- a/dist/ui/debugPanel.js
+++ b/dist/ui/debugPanel.js
@@ -1,7 +1,8 @@
 // ===== FILE: debugPanel.ts =====
 // [SECTION_ID]: debug-overlay-mode1
 // Purpose: Display a developer overlay with live game information
-import { DEBUG_MODE } from '../config/settings';
+// [AI_EDIT] 2025-08-03 - Added .js extension to config import
+import { DEBUG_MODE } from '../config/settings.js';
 // Cached DOM references for quick updates
 let panel = null;
 let traceLabel = null;

--- a/src/core/gameLoop.ts
+++ b/src/core/gameLoop.ts
@@ -2,7 +2,8 @@
 // [SECTION_ID]: game-loop-core
 // Purpose: Contains the central game loop for updating and drawing the game
 
-import { DEBUG_MODE } from '../config/settings';
+// [AI_EDIT] 2025-08-03 - Added .js extension to config import
+import { DEBUG_MODE } from '../config/settings.js';
 
 /** Starts the placeholder game loop */
 export function startGameLoop(canvas: HTMLCanvasElement): void {

--- a/src/core/traceEngine.ts
+++ b/src/core/traceEngine.ts
@@ -6,7 +6,8 @@ import {
   DEBUG_MODE,
   TRACE_DISTANCE_THRESHOLD,
   SOUND_ENABLED,
-} from '../config/settings';
+// [AI_EDIT] 2025-08-03 - Added .js extension to config import
+} from '../config/settings.js';
 
 /** A point on the canvas */
 export interface Point {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,10 @@
 // [SECTION_ID]: canvas-init-main
 // Purpose: Initialize the full-screen canvas and kick off the game loop
 
-import { DEBUG_MODE } from './config/settings';
-import { startGameLoop } from './core/gameLoop';
-import { startPracticeMode } from './scenes/mode1';
+// [AI_EDIT] 2025-08-03 - Added .js extensions for browser module support
+import { DEBUG_MODE } from './config/settings.js';
+import { startGameLoop } from './core/gameLoop.js';
+import { startPracticeMode } from './scenes/mode1.js';
 
 /**
  * Configures the on-page canvas to fill the screen.

--- a/src/scenes/mode1.ts
+++ b/src/scenes/mode1.ts
@@ -2,6 +2,7 @@
 // [SECTION_ID]: mode1-scene-animation
 // Purpose: Handles "Practice" mode where the child traces one animal at a time
 
+// [AI_EDIT] 2025-08-03 - Added .js extensions for browser module support
 import {
   startTracking,
   stopTracking,
@@ -9,13 +10,13 @@ import {
   isTraceAccurate,
   Point,
   loadAnimalOutline,
-} from '../core/traceEngine';
-import { DEBUG_MODE } from '../config/settings';
+} from '../core/traceEngine.js';
+import { DEBUG_MODE } from '../config/settings.js';
 import {
   showDebugPanel,
   updateTraceCount,
   clearDebugPanel,
-} from '../ui/debugPanel';
+} from '../ui/debugPanel.js';
 
 let ctx: CanvasRenderingContext2D;
 let currentOutline: Point[] = [];

--- a/src/scenes/mode2.ts
+++ b/src/scenes/mode2.ts
@@ -2,6 +2,7 @@
 // [SECTION_ID]: intermediate-mode-multitrace
 // Purpose: Handles "Intermediate" mode where 2–3 animals can be traced in any order
 
+// [AI_EDIT] 2025-08-03 - Added .js extensions for browser module support
 import {
   startTracking,
   stopTracking,
@@ -9,8 +10,8 @@ import {
   isTraceAccurate,
   loadAnimalOutline,
   Point,
-} from '../core/traceEngine';
-import { DEBUG_MODE } from '../config/settings';
+} from '../core/traceEngine.js';
+import { DEBUG_MODE } from '../config/settings.js';
 
 /** Represents one animal currently on the screen */
 interface ActiveAnimal {

--- a/src/ui/debugPanel.ts
+++ b/src/ui/debugPanel.ts
@@ -2,7 +2,8 @@
 // [SECTION_ID]: debug-overlay-mode1
 // Purpose: Display a developer overlay with live game information
 
-import { DEBUG_MODE } from '../config/settings';
+// [AI_EDIT] 2025-08-03 - Added .js extension to config import
+import { DEBUG_MODE } from '../config/settings.js';
 
 /** Information shown on the debug panel */
 interface DebugInfo {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "rootDir": "./src",
     "target": "ES6",
     "module": "ES6",
-    "moduleResolution": "node",
+    // [AI_EDIT] 2025-08-03 - Use bundler resolution to allow .js imports
+    "moduleResolution": "bundler",
     "strict": true
   }
 }


### PR DESCRIPTION
## Summary
- ensure compiled JS modules reference .js files for GitHub Pages
- adjust TypeScript config for bundler-style resolution

## Testing
- `npx tsc`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688d861de3fc83308f08cd0e5cbc64de